### PR TITLE
Use arrow-cpp's run_export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - r-tidyselect
   run:
     - r-base
-    - {{ pin_compatible('arrow-cpp') }}
     - {{native}}gcc-libs         # [win]
     - r-r6
     - r-rcpp >=0.12.18.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  number: 0
+  number: 1
   skip: True  # [win]
   rpaths:
     - lib/R/lib/


### PR DESCRIPTION
Makes sure we use `arrow-cpp`'s `run_export` to determine the version of `arrow-cpp` we use at runtime.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/r-arrow-feedstock/issues/11

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/321#issuecomment-550536461