### PR TITLE
Re-enable windows builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,7 @@ requirements:
     - r-purrr
     - r-rlang
     - r-tidyselect
+    - r-tzdb            # [win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 9d280d8042e7cf526f8c28d170d93bfab65e50f94569f6a790982a878d8d898d
 
 build:
-  skip: true  # [win]
   number: 1
   rpaths:
     - lib/R/lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,8 @@ package:
   version: {{ version|replace("-", "_") }}
 
 source:
-  url: https://dist.apache.org/repos/dist/release/arrow/arrow-{{ version }}/apache-arrow-{{ version }}.tar.gz
+  url: https://www.apache.org/dyn/closer.lua/arrow/arrow-{{ version }}/apache-arrow-{{ version }}.tar.gz?action=download
+  fn: apache-arrow-{{ version }}.tar.gz
   sha256: 9d280d8042e7cf526f8c28d170d93bfab65e50f94569f6a790982a878d8d898d
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ requirements:
     - r-base
     - r-r6
     - r-cpp11
+    # https://github.com/r-lib/cpp11/issues/360
+    - r-cpp11 <0.4.4    # [win]
     - r-assertthat
     - r-bit64
     - r-purrr


### PR DESCRIPTION
This is essentially a rebase of #81, though the bot tried windows in #83 as well, where it failed with
```
D:/bld/r-arrow_1721257668194/_h_env/lib/R/include\Rinternals.h:34:11: fatal error: 'cstdio' file not found
   34 | # include <cstdio>
      |           ^~~~~~~~
```

----

update: due to https://github.com/apache/arrow/issues/43398 & https://github.com/r-lib/cpp11/issues/360

Closes #81 
Closes #79